### PR TITLE
Optimize HEIC conversion

### DIFF
--- a/Sources/SnapshotTestingHEIC/HEIC/UIImage+HEIC.swift
+++ b/Sources/SnapshotTestingHEIC/HEIC/UIImage+HEIC.swift
@@ -1,10 +1,22 @@
 #if os(iOS) || os(tvOS)
 import AVFoundation
 import UIKit
+import ObjectiveC
 
 @available(tvOSApplicationExtension 11.0, *)
+private var heicCacheKey: UInt8 = 0
+
 extension UIImage {
+    /// Returns HEIC data for the image. Result is cached per compression quality
+    /// to avoid repeated expensive conversions during snapshot tests.
     func heicData(compressionQuality: CGFloat) -> Data? {
+
+        // Retrieve cached data if available
+        if let cache = objc_getAssociatedObject(self, &heicCacheKey) as? [NSNumber: Data],
+           let data = cache[NSNumber(value: Float(compressionQuality))] {
+            return data
+        }
+
         let data = NSMutableData()
 
         guard let imageDestination = CGImageDestinationCreateWithData(
@@ -12,24 +24,24 @@ extension UIImage {
         )
         else { return nil }
 
-        guard let cgImage = cgImage 
-        else { return nil }
+        guard let cgImage = cgImage else { return nil }
 
-        let options: NSDictionary?
-        if compressionQuality >= 1 {
-            options = nil
-        } else {
-            options = [
-                kCGImageDestinationLossyCompressionQuality: compressionQuality
-            ]
-        }
+        let options: NSDictionary? = compressionQuality >= 1
+            ? nil
+            : [kCGImageDestinationLossyCompressionQuality: compressionQuality]
 
         CGImageDestinationAddImage(imageDestination, cgImage, options)
 
-        guard CGImageDestinationFinalize(imageDestination) 
-        else { return nil }
+        guard CGImageDestinationFinalize(imageDestination) else { return nil }
 
-        return data as Data
+        let result = data as Data
+
+        // Cache result for subsequent calls
+        var cache = objc_getAssociatedObject(self, &heicCacheKey) as? [NSNumber: Data] ?? [:]
+        cache[NSNumber(value: Float(compressionQuality))] = result
+        objc_setAssociatedObject(self, &heicCacheKey, cache, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+        return result
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- cache results of HEIC conversion so tests don't repeatedly re-encode the same image

## Testing
- `swift build`
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68750d9c1c44832aaf524d3c96c33f77